### PR TITLE
Use lighter API call to verify access token

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports.getSetup = ({ chalk, currentOptions, inquirer, log }) => {
         useCdn: options.useCdn
       });
 
-      await client.fetch("*", {});
+      await client.fetch("1", {});
     } catch (error) {
       console.log("");
       log(


### PR DESCRIPTION
It seems the ```client.fetch("*", {})``` call was used only for checking for any `Unauthorized - Session not found` errors. Since the `*` query returns all documents the token has access to, this operation could get expensive (in bandwidth and time) for some users. Changing this query to return something like `1` will achieve the same, but in a much lighter way.