### PR TITLE
Add assets metadata block

### DIFF
--- a/lib/sanity-util.js
+++ b/lib/sanity-util.js
@@ -76,12 +76,18 @@ function getMetadataBlock({ entry, options }) {
 }
 
 function normalizeAsset({ entry, options }) {
-    return {
+    const asset = {
         ...getMetadataBlock({ entry, options }),
         contentType: entry.mimeType,
         fileName: entry.originalFilename,
         url: entry.url
     };
+
+    if (entry.metadata) {
+        asset.metadata = entry.metadata;
+    }
+
+    return asset;
 }
 
 function normalizeEntries({ entries, options }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,6 +769,11 @@
                 "fastq": "^1.6.0"
             }
         },
+        "@rexxars/eventsource-polyfill": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@rexxars/eventsource-polyfill/-/eventsource-polyfill-1.0.0.tgz",
+            "integrity": "sha512-YnrybIoM9WFqmeK1D8p/gutqjJnmXCVFWAU3ucka9M7Dzpen3f2Dy4KsC6k1wDHrCtHQuUHHwZovh3i5UPDaZw=="
+        },
         "@samverschueren/stream-to-observable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -813,32 +818,32 @@
             }
         },
         "@sanity/client": {
-            "version": "0.147.3",
-            "resolved": "https://registry.npmjs.org/@sanity/client/-/client-0.147.3.tgz",
-            "integrity": "sha512-wXWL1mPyQZB+1te2KPtSX2zQ0rc+/Ol4DsQYUQ7gY0N/ESWXqLuD14ixWAkLNGy1SbK3ZDLuTrGOstpb7va+Gw==",
+            "version": "1.149.18",
+            "resolved": "https://registry.npmjs.org/@sanity/client/-/client-1.149.18.tgz",
+            "integrity": "sha512-yuJt7t56jkgrSkg3rXGSsrD81+a/0CLnj18JyTqLWAkojihqD2/KjYy0XOTELFUVk74Z6d6pHnNt0CpqTzlGLQ==",
             "requires": {
-                "@sanity/eventsource": "0.147.0",
-                "@sanity/generate-help-url": "0.147.0",
-                "@sanity/observable": "0.147.0",
+                "@sanity/eventsource": "1.149.16",
+                "@sanity/generate-help-url": "1.149.16",
+                "@sanity/observable": "1.149.16",
                 "deep-assign": "^2.0.0",
-                "get-it": "^5.0.0",
+                "get-it": "^5.0.3",
                 "make-error": "^1.3.0",
                 "object-assign": "^4.1.1"
             }
         },
         "@sanity/eventsource": {
-            "version": "0.147.0",
-            "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-0.147.0.tgz",
-            "integrity": "sha512-06XsHijSkIyz39Pkx/nNKOVDwXhLtUoYx98WirCUF3TdRt8tGQ6W/GCOSufcv4RdyQRi1d8FRwBS+kE3lxf5Fg==",
+            "version": "1.149.16",
+            "resolved": "https://registry.npmjs.org/@sanity/eventsource/-/eventsource-1.149.16.tgz",
+            "integrity": "sha512-sLacIXQ2Cr+BfDkgmXdUgu+AMNBPMspJDt3oOfB628zqLN2HjSg6Qz8H9wZk8v4DQI3tCKiIpi7xbf9T/7VUUA==",
             "requires": {
-                "eventsource": "^1.0.6",
-                "eventsource-polyfill": "^0.9.6"
+                "@rexxars/eventsource-polyfill": "^1.0.0",
+                "eventsource": "^1.0.6"
             }
         },
         "@sanity/generate-help-url": {
-            "version": "0.147.0",
-            "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.147.0.tgz",
-            "integrity": "sha512-jf0PWK7dpSSJUI0zJdh+PFUODmsP5dS6P9iYv/ufhyYzmD+2iV7YCpA6weNhsmNGnil2+CTj6Eg43tSKxiClRA=="
+            "version": "1.149.16",
+            "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-1.149.16.tgz",
+            "integrity": "sha512-+lJPqs88i6KMo21Twr6YnZ1hjIOQ8Utz5xTFrTn+55egU4dh+bI03cI4AC1LpTzQsuefKvz22/12pz9ejHGKhw=="
         },
         "@sanity/image-url": {
             "version": "0.140.17",
@@ -846,9 +851,9 @@
             "integrity": "sha512-RWyrTXmdDwujYZ2Rpd7eqKTfbr+rAcZ6zWlCqEtGG0mQwV/O22AoiL++lKq6YHsOn/etl6CsqrQAsEQNMF4r1A=="
         },
         "@sanity/observable": {
-            "version": "0.147.0",
-            "resolved": "https://registry.npmjs.org/@sanity/observable/-/observable-0.147.0.tgz",
-            "integrity": "sha512-sQZD1fyEP8HxW3wIT9M90myg1yp4BcMr3/Q9Cu+D3ubIliTFIefi3z0WetQwEvUNq0SQE99242a+lhDFmcmTEg==",
+            "version": "1.149.16",
+            "resolved": "https://registry.npmjs.org/@sanity/observable/-/observable-1.149.16.tgz",
+            "integrity": "sha512-7lySGcikzutob7mLv0OxQ4UE5sGYXoTMWDy/VVsSdrRkCta0/jCN8q0mfrpep4fJeOy5Sujr2xz//ga8eFDfAQ==",
             "requires": {
                 "object-assign": "^4.1.1",
                 "rxjs": "^6.5.3"
@@ -1749,9 +1754,9 @@
             "dev": true
         },
         "debug": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "requires": {
                 "ms": "2.0.0"
             }
@@ -2012,11 +2017,6 @@
             "requires": {
                 "original": "^1.0.0"
             }
-        },
-        "eventsource-polyfill": {
-            "version": "0.9.6",
-            "resolved": "https://registry.npmjs.org/eventsource-polyfill/-/eventsource-polyfill-0.9.6.tgz",
-            "integrity": "sha1-EODRh/ERsWfyj9q5GIQ859gY8Tw="
         },
         "exec-sh": {
             "version": "0.3.4",
@@ -2282,12 +2282,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-            "requires": {
-                "debug": "=3.1.0"
-            }
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
+            "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg=="
         },
         "for-in": {
             "version": "1.0.2",
@@ -2367,9 +2364,9 @@
             "dev": true
         },
         "get-it": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.2.tgz",
-            "integrity": "sha512-nEbFn2HvKFWSl8CNmiMZs7prWSwQELCmFak+4NMaTtrB23ePpVKf3/bpjdTjsjWMc/W2a4SrChvmgqwa8fO8UQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/get-it/-/get-it-5.0.3.tgz",
+            "integrity": "sha512-S/QxA9/P4e0tHPILIdf92FVYrE0vre7ChXXMZoILuU4/keatMqnW1KAzCEOH8toJVbj+hgrOnZdUxd9ruG7lsQ==",
             "requires": {
                 "@sanity/timed-out": "^4.0.2",
                 "create-error-class": "^3.0.2",
@@ -2392,14 +2389,6 @@
                 "url-parse": "^1.1.9"
             },
             "dependencies": {
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
                 "is-stream": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -2708,9 +2697,9 @@
             "dev": true
         },
         "in-publish": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-            "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+            "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
         },
         "indent-string": {
             "version": "4.0.0",
@@ -4100,9 +4089,9 @@
             }
         },
         "make-error": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
-            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g=="
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
         },
         "makeerror": {
             "version": "1.0.11",
@@ -5329,9 +5318,9 @@
             "dev": true
         },
         "simple-concat": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-            "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
         },
         "sisteransi": {
             "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "dependencies": {
         "@sanity/block-content-to-html": "^1.3.8",
         "@sanity/block-content-to-markdown": "0.0.5",
-        "@sanity/client": "^0.147.3"
+        "@sanity/client": "^1.149.18"
     },
     "devDependencies": {
         "@stackbit/prettier-config": "^1.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -338,7 +338,7 @@ describe('`transform()`', () => {
         expect(model1.projectId).toBe(mockOptions.projectId);
         expect(model1.source).toBe('sourcebit-source-sanity');
 
-        expect(model2.fieldNames).toEqual(['contentType', 'fileName', 'url']);
+        expect(model2.fieldNames).toEqual(['contentType', 'fileName', 'url', 'metadata']);
         expect(model2.modelName).toBe('__asset');
         expect(model2.projectEnvironment).toBe(mockOptions.dataset);
         expect(model2.projectId).toBe(mockOptions.projectId);
@@ -380,7 +380,7 @@ describe('`transform()`', () => {
         expect(model1.projectId).toBe(mockOptions.projectId);
         expect(model1.source).toBe('sourcebit-source-sanity');
 
-        expect(model2.fieldNames).toEqual(['contentType', 'fileName', 'url']);
+        expect(model2.fieldNames).toEqual(['contentType', 'fileName', 'url', 'metadata']);
         expect(model2.modelName).toBe('__asset');
         expect(model2.projectEnvironment).toBe(mockOptions.dataset);
         expect(model2.projectId).toBe(mockOptions.projectId);

--- a/test/sanity-util.test.js
+++ b/test/sanity-util.test.js
@@ -1,4 +1,5 @@
 const sanityUtil = require('../lib/sanity-util');
+const { normalizeEntries } = require('../lib/sanity-util');
 
 describe('`normalizeEntries()`', () => {
     const mockEntries = {
@@ -275,6 +276,7 @@ describe('`normalizeEntries()`', () => {
                     createdAt: '2020-01-29T14:00:00Z',
                     updatedAt: '2020-01-29T15:00:00Z'
                 },
+                metadata: mockEntries['image-48ef6974717f0ff28c9fe64392d487423c5f041b-1000x667-jpg'].metadata,
                 contentType: 'image/jpeg',
                 fileName: '7.jpg',
                 url: 'https://cdn.sanity.io/images/kz6i252u/production/48ef6974717f0ff28c9fe64392d487423c5f041b-1000x667.jpg'
@@ -342,6 +344,7 @@ describe('`normalizeEntries()`', () => {
                     createdAt: '2020-01-29T14:00:00Z',
                     updatedAt: '2020-01-29T15:00:00Z'
                 },
+                metadata: mockEntries['image-48ef6974717f0ff28c9fe64392d487423c5f041b-1000x667-jpg'].metadata,
                 contentType: 'image/jpeg',
                 fileName: '7.jpg',
                 url: 'https://cdn.sanity.io/images/kz6i252u/production/48ef6974717f0ff28c9fe64392d487423c5f041b-1000x667.jpg'
@@ -377,6 +380,7 @@ describe('`normalizeEntries()`', () => {
                 createdAt: '2020-01-29T14:00:00Z',
                 updatedAt: '2020-01-29T15:00:00Z'
             },
+            metadata: mockEntries['image-48ef6974717f0ff28c9fe64392d487423c5f041b-1000x667-jpg'].metadata,
             contentType: 'image/jpeg',
             fileName: '7.jpg',
             url: 'https://cdn.sanity.io/images/kz6i252u/production/48ef6974717f0ff28c9fe64392d487423c5f041b-1000x667.jpg'


### PR DESCRIPTION
This PR changes the asset normalisation routine to include the Sanity `metadata` block if it's present.

Closes #5.